### PR TITLE
解决mapstruct在eclipse生成不了mapper的实现类的问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,10 @@
     <version>1.0.4.RELEASE</version>
   </parent>
 
+	<properties>
+		<!-- automatically run annotation processors within the incremental compilation -->
+		<m2e.apt.activation>jdt_apt</m2e.apt.activation>
+	</properties>
 
   <dependencies>
 


### PR DESCRIPTION
需要先在eclipse中安装m2e-apt插件
http://mapstruct.org/documentation/ide-support/